### PR TITLE
add github workflow for publishing to pypi

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -1,47 +1,40 @@
 name: Publish to PyPI
 
 on:
-  workflow_run:
-    workflows: ["Increment patch version"]
-    types:
-      - completed
+  # Allows manual run from the Actions tab
   workflow_dispatch:
 
 jobs:
   build:
     name: Build distribution 📦
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
+    - name: Checkout repo
+      uses: actions/checkout@v4
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: "3.x"
-    - name: Install pypa/build
-      run: >-
-        python3 -m 
-        pip install build --user
-    - name: Build a binary wheel and a source tarball
-      run: python3 -m build
-    - name: Store the distribution packages
+    - name: Build
+      run: |
+        python3 -m pip install build --user
+        python3 -m build
+    - name: Store packages
       uses: actions/upload-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
 
   publish-to-pypi:
-    name: >-
-      Publish Python 🐍 distribution 📦 to PyPI
+    name: Publish Python 🐍 distribution 📦 to PyPI
+    runs-on: ubuntu-latest
     needs:
     - build
-    runs-on: ubuntu-latest
     environment:
       name: pypi
       url: https://pypi.org/p/rastertoolkit
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
-
     steps:
     - name: Download all the dists
       uses: actions/download-artifact@v4

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -1,0 +1,52 @@
+name: Publish to PyPI
+
+on:
+  workflow_run:
+    workflows: ["Increment patch version"]
+    types:
+      - completed
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build distribution 📦
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.x"
+    - name: Install pypa/build
+      run: >-
+        python3 -m 
+        pip install build --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/rastertoolkit
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -32,7 +32,7 @@ jobs:
     - build
     environment:
       name: pypi
-      url: https://pypi.org/p/rastertoolkit
+      url: https://pypi.org/project/rastertoolkit
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the publishing of Python packages to PyPI. The workflow is triggered either upon completion of the "Increment patch version" workflow or manually via workflow dispatch.

Automation for publishing Python packages:

* [`.github/workflows/publish_pypi.yml`](diffhunk://#diff-22966fe1865c208453d2318c03d1247f3106dad4d5e5ea4dbb3e2ebcf1d0065bR1-R52): Added a workflow named "Publish to PyPI" with two jobs: `build` (to create distribution packages) and `publish-to-pypi` (to upload the packages to PyPI). The workflow uses GitHub Actions like `actions/checkout`, `actions/setup-python`, `actions/upload-artifact`, and `pypa/gh-action-pypi-publish` for automation.

I have added this as a trusted publisher.